### PR TITLE
EIUNAB-3645/Impact : Work with Teams to get the YAML into Backstage.io for all projects

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: economist-impact
   annotations:
     github.com/project-slug: signal-noise/containers
+      # the circleCI project, mirrors github repo in this case: 
+    circleci.com/project-slug: github/signal-noise/containers
+      # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw
+    description: covid-relative-risk for SignalNoise Economist Impact Project
+    opsgenie:
+      domain: https://economist.app.opsgenie.com/teams/dashboard/49177ca8-5e59-4364-af23-c22cc60c026f/main
     backstage.io/techdocs-ref: dir:.
 spec:
   type: library

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1beta1
+kind: Component
+metadata:
+  name: containers
+  namespace: economist-impact
+  annotations:
+    github.com/project-slug: signal-noise/containers
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: library
+  lifecycle: production
+  owner: group:economist-impact/signal-noise

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+> Docker images for use in CI
+
+Based on official NodeJS/Alpine distros, with tooling for compatibility with
+CircleCI and GCP as well as AWS.
+
+Note that this repo connects to auto-build functionality on Docker Hub.
+
+Different branches on this repo represent different Docker Hub 'Repositories',
+while folders represent version numbers. Tags are not used.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+docs_dir: docs
+nav:
+  - Main: index.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
Description
Add to Backstage - Economist Impact Signal Noise Team

Reason for change
Backstage.io rollout across the Economist Group via platform.economist.com

Breaking changes
None

Remarks
Github added, CircleCI Added (where CICD applicable), New Relic added, Opsgenie added (where applicable), docs file added to be updated in depth by the team upon review.

Testing
Once merged the Enablement team will test integration into backstage. The yaml files are pulled via polling on the main branch for automated incorporation.

Checklist
My commits, pull request name follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
style
I have made corresponding changes to the documentation
I have updated unit tests, integration tests
I have tested in dev environment
I have update swagger, where applicable
I have provided cdk diff result for infrastructure changes, where applicable